### PR TITLE
added ExternalHook; support for specifying hook on cli

### DIFF
--- a/detect_secrets_server/__main__.py
+++ b/detect_secrets_server/__main__.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import codecs
-import os.path
 import sys
 
 import yaml
@@ -261,7 +260,12 @@ def main(argv=None):
 
         print('# detect-secrets scanner')
         for repo in cron_repos:
-            print(repo.cron())
+            print(
+                '{} {}'.format(
+                    repo.cron(),
+                    args.output_hook_command,
+                )
+            )
 
     elif args.add_repo:
         add_repo(

--- a/detect_secrets_server/__main__.py
+++ b/detect_secrets_server/__main__.py
@@ -9,7 +9,6 @@ import yaml
 from detect_secrets.core.log import CustomLog
 from detect_secrets.plugins import SensitivityValues
 
-from detect_secrets_server.hooks.pysensu_yelp import PySensuYelpHook
 from detect_secrets_server.repos import tracked_repo_factory
 from detect_secrets_server.repos.base_tracked_repo import DEFAULT_BASE_TMP_DIR
 from detect_secrets_server.repos.base_tracked_repo import OverrideLevel
@@ -19,7 +18,6 @@ from detect_secrets_server.usage import ServerParserBuilder
 
 
 CustomLogObj = CustomLog()
-PYSENSU_CONFIG = '.pysensu.config.yaml'
 
 
 def open_config_file(config_file):
@@ -300,8 +298,7 @@ def main(argv=None):
                 'secrets': secrets,
             }
             log.error(alert)
-            if os.path.isfile(PYSENSU_CONFIG):
-                PySensuYelpHook(PYSENSU_CONFIG).alert(secrets, repo.name)
+            args.output_hook.alert(repo.name, secrets)
         else:
             log.info('SCAN COMPLETE - STATUS: clean for %s', repo.name)
 

--- a/detect_secrets_server/hooks/base.py
+++ b/detect_secrets_server/hooks/base.py
@@ -20,4 +20,3 @@ class BaseHook(object):  # pragma: no cover
         :param secrets: dictionary; where keys are filenames
         """
         pass
-

--- a/detect_secrets_server/hooks/base.py
+++ b/detect_secrets_server/hooks/base.py
@@ -1,10 +1,23 @@
+from abc import ABCMeta
+from abc import abstractmethod
+
+
 class BaseHook(object):  # pragma: no cover
     """This is an abstract class to define Hooks API. A hook is an alerting system
     that allows you connect your server scanning results to your larger ecosystem
-    (eg. email alerts, IRC pings...)"""
+    (eg. email alerts, IRC pings...)
+    """
 
-    def alert(self, data):
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def alert(self, repo_name, secrets):
         """
-        :param data: dictionary; where keys are filenames
+        :type repo_name: str
+        :param repo_name: the repository where secrets were found.
+
+        :type secrets: dict
+        :param secrets: dictionary; where keys are filenames
         """
-        raise NotImplementedError
+        pass
+

--- a/detect_secrets_server/hooks/external.py
+++ b/detect_secrets_server/hooks/external.py
@@ -1,0 +1,27 @@
+"""
+This provides a common interface to run arbitrary scripts, provided
+by the `--output-hook` option.
+
+The script you provide must be executable, and accept two command line
+inputs:
+    1. the name of the repository where secrets are found, and
+    2. the json output of secrets found.
+"""
+import json
+import subprocess
+
+from .base import BaseHook
+
+
+class ExternalHook(BaseHook):
+
+    def __init__(self, filename):
+        self.filename = filename
+
+    def alert(self, repo_name, secrets):
+        subprocess.call([
+            self.filename,
+            repo_name,
+            json.dumps(secrets),
+        ])
+

--- a/detect_secrets_server/hooks/external.py
+++ b/detect_secrets_server/hooks/external.py
@@ -24,4 +24,3 @@ class ExternalHook(BaseHook):
             repo_name,
             json.dumps(secrets),
         ])
-

--- a/detect_secrets_server/hooks/pysensu_yelp.py
+++ b/detect_secrets_server/hooks/pysensu_yelp.py
@@ -44,5 +44,4 @@ class PySensuYelpHook(BaseHook):
 
     def alert(self, repo_name, secrets):
         self.config_data['output'] = "In repo " + repo_name + "\n" + str(secrets)
-        pysensu_yelp.send_event(**config_data)
-
+        pysensu_yelp.send_event(**self.config_data)

--- a/detect_secrets_server/usage.py
+++ b/detect_secrets_server/usage.py
@@ -1,6 +1,16 @@
 from __future__ import absolute_import
 
+import argparse
+from collections import namedtuple
+import json
+from importlib import import_module
+import os
+import subprocess
+import sys
+
 from detect_secrets.core.usage import ParserBuilder
+
+from detect_secrets_server.hooks.external import ExternalHook
 
 
 class ServerParserBuilder(ParserBuilder):
@@ -8,8 +18,19 @@ class ServerParserBuilder(ParserBuilder):
 
     def __init__(self):
         super(ServerParserBuilder, self).__init__()
+        self.output_parser = OutputOptions(self.parser)
 
         self._add_server_arguments()
+
+    def parse_args(self, argv):
+        output = super(ServerParserBuilder, self).parse_args(argv)
+
+        try:
+            self.output_parser.consolidate_args(output)
+        except argparse.ArgumentTypeError as e:
+            self.parser.error(e)
+
+        return output
 
     def _add_server_arguments(self):
         self._add_initialize_server_argument()\
@@ -19,6 +40,8 @@ class ServerParserBuilder(ParserBuilder):
             ._add_local_repo_flag()\
             ._add_s3_config_file_argument()\
             ._add_set_baseline_argument()
+
+        self.output_parser.add_arguments()
 
     def _add_initialize_server_argument(self):
         self.parser.add_argument(
@@ -87,3 +110,165 @@ class ServerParserBuilder(ParserBuilder):
         )
 
         return self
+
+
+class HookDescriptor(namedtuple(
+    'HookDescriptor',
+    (
+        # The value that users can input, to refer to this hook.
+        'display_name',
+
+        # module name of plugin, used for initialization
+        'module_name',
+
+        'class_name',
+
+        # A HookDescriptor config enum
+        'config_setting',
+    )
+)):
+    CONFIG_NOT_SUPPORTED = 0
+    CONFIG_OPTIONAL = 1
+    CONFIG_REQUIRED = 2
+
+    def __new__(cls, config_setting=None, **kwargs):
+        if config_setting is None:
+            config_setting = cls.CONFIG_NOT_SUPPORTED
+
+        return super(HookDescriptor, cls).__new__(
+            cls,
+            config_setting=config_setting,
+            **kwargs,
+        )
+
+
+class OutputOptions(object):
+
+    all_hooks = [
+        HookDescriptor(
+            display_name='pysensu',
+            module_name='detect_secrets_server.hooks.pysensu_yelp',
+            class_name='PySensuYelpHook',
+            config_setting=HookDescriptor.CONFIG_REQUIRED,
+        ),
+    ]
+
+    def __init__(self, parser):
+        self.parser = parser.add_argument_group(
+            title='output',
+            description=(
+                'Configure output method, for alerting upon secrets found in '
+                'tracked repository.'
+            ),
+        )
+
+    def add_arguments(self):
+        self.parser.add_argument(
+            '--output-hook',
+            type=self._is_valid_hook,
+            help=(
+                'Either one of the pre-registered hooks ({}) '
+                'or a path to a valid executable file.'.format(
+                    ', '.join(
+                        map(
+                            lambda x: x.display_name,
+                            self.all_hooks,
+                        )
+                    )
+                )
+            ),
+            metavar='HOOK',
+        )
+
+        self.parser.add_argument(
+            '--output-config',
+            type=is_config_file,
+            help=(
+                'Configuration file to initialize output hook, if required.'
+            ),
+            metavar='CONFIG_FILENAME',
+        )
+
+    def consolidate_args(self, args):
+        if args.output_hook:
+            args.output_hook = self._initialize_output_hook(args)
+            delattr(args, 'output_config') 
+
+        return args
+
+    def _is_valid_hook(self, hook):
+        """
+        A valid hook is either one of the pre-defined hooks, or a filename
+        to an arbitrary executable script (for further customization).
+        """
+        for registered_hook in self.all_hooks:
+            if hook == registered_hook.display_name:
+                return hook
+
+        is_valid_file(
+            hook,
+            [
+                '\noutput-hook must be one of the following values:\n' + \
+                '\n'.join(
+                    map(
+                        lambda x: '  - ' + x.display_name,
+                        self.all_hooks,
+                    )
+                ) + \
+                '\nor a valid executable filename.\n' + \
+                '"{}" does not qualify.'.format(hook),
+            ],
+        )
+        return hook
+
+    def _initialize_output_hook(self, args):
+        hook_found = None
+       
+        for hook in self.all_hooks:
+            if args.output_hook == hook.display_name:
+                hook_found = hook
+                break
+ 
+        if not hook_found:
+            return ExternalHook(args.output_hook)        
+
+        if hook_found.config_setting == HookDescriptor.CONFIG_REQUIRED and \
+                not args.output_config:
+            # We want to display this error, as if it was during argument validation.
+            raise argparse.ArgumentTypeError(
+                '{} hook requires a config file. '
+                'Pass one in through --output-config.'.format(
+                    hook_found.display_name,
+                )
+            )
+
+        # These values are not user injectable, so it should be ok.
+        module = import_module(hook_found.module_name)
+        hook_class = getattr(module, hook_found.class_name)
+
+        if hook_found.config_setting == HookDescriptor.CONFIG_NOT_SUPPORTED:
+            return hook_class()
+        
+        return hook_class(args.output_config)
+
+
+def is_valid_file(path, error_msg=None):
+    if not os.path.exists(path):
+        if not error_msg:
+            error_msg = 'File does not exist: %s' % path
+
+        raise argparse.ArgumentTypeError(error_msg)
+
+    return path
+
+
+def is_config_file(path):
+    """
+    Custom type to enforce input is valid filepath, and if valid,
+    extract file contents.
+    """
+    is_valid_file(path)
+
+    with open(path) as f:
+        return f.read()
+

--- a/detect_secrets_server/usage.py
+++ b/detect_secrets_server/usage.py
@@ -135,7 +135,7 @@ class HookDescriptor(namedtuple(
         return super(HookDescriptor, cls).__new__(
             cls,
             config_setting=config_setting,
-            **kwargs,
+            **kwargs
         )
 
 

--- a/detect_secrets_server/usage.py
+++ b/detect_secrets_server/usage.py
@@ -196,6 +196,8 @@ class OutputOptions(object):
         if args.output_hook:
             args.output_hook, args.output_hook_command = \
                 self._initialize_output_hook_and_raw_command(args)
+
+            # This is not needed anymore
             delattr(args, 'output_config')
 
         return args

--- a/examples/standalone_hook.py
+++ b/examples/standalone_hook.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3.6
+"""
+This is an example bare-bone script that you can use as an argument for
+setting up an output hook.
+
+>>> $ detect-secrets-server --scan-repo yelp/detect-secrets
+...     --output-hook examples/standalone_hook.py
+"""
+import json
+import sys
+
+
+def main():
+    print('repo:', sys.argv[1])
+    print(sys.argv[2])
+    print(json.dumps(json.loads(sys.argv[2]), indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -499,11 +499,10 @@ class ServerTest(unittest.TestCase):
             'baseline_file': '.secrets.baseline',
         }, indent=2))
 
-    @mock.patch('detect_secrets_server.__main__.os.path.isfile')
     @mock.patch('detect_secrets_server.__main__.CustomLogObj.getLogger')
     @mock.patch('detect_secrets_server.repos.base_tracked_repo.BaseTrackedRepo.scan')
     @mock.patch('detect_secrets_server.repos.base_tracked_repo.BaseTrackedRepo._read_tracked_file')
-    def test_main_scan_repo_scan_success_secrets_found(self, mock_file, mock_scan, mock_log, mock_is_file):
+    def test_main_scan_repo_scan_success_secrets_found(self, mock_file, mock_scan, mock_log):
         mock_file.return_value = {
             'sha': 'does_not_matter',
             'repo': 'repo_name',
@@ -513,7 +512,6 @@ class ServerTest(unittest.TestCase):
             'cron': '* * * * *',
             'baseline_file': '.secrets.baseline',
         }
-        mock_is_file.return_value = True
 
         mock_secret_collection = SecretsCollection()
         mock_secret_collection.data['junk'] = 'data'

--- a/tests/usage_test.py
+++ b/tests/usage_test.py
@@ -1,0 +1,54 @@
+from __future__ import absolute_import
+
+import pytest
+
+from detect_secrets_server.usage import ServerParserBuilder
+from detect_secrets_server.hooks.external import ExternalHook
+from detect_secrets_server.hooks.pysensu_yelp import PySensuYelpHook
+
+
+class TestOutputOptions(object):
+
+    @staticmethod
+    def parse_args(argument_string=''):
+        return ServerParserBuilder().parse_args(argument_string.split())
+
+    @pytest.mark.parametrize(
+        'hook_input',
+        [
+            # No such hook
+            'asdf',
+
+            # config file required
+            'pysensu',
+
+            # no such file
+            'test_data/invalid_file',
+        ]
+    )
+    def test_invalid_output_hook(self, hook_input):
+        with pytest.raises(SystemExit):
+            self.parse_args('--output-hook {}'.format(hook_input))
+ 
+    @pytest.mark.parametrize(
+        'hook_input,instance_type',
+        [
+            (
+                # For testing purposes, the exact config does not
+                # matter; it just needs to be yaml loadable.
+                'pysensu --output-config repos.yaml.sample',
+                PySensuYelpHook,                
+            ),
+            (
+                'setup.py',
+                ExternalHook,
+            ),
+        ]
+    )
+    def test_valid_output_hook(self, hook_input, instance_type):
+        args = self.parse_args('--output-hook {}'.format(hook_input))
+        assert isinstance(args.output_hook, instance_type)
+
+        with pytest.raises(AttributeError):
+            getattr(args, 'output_config')
+

--- a/tests/usage_test.py
+++ b/tests/usage_test.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import
 
 import pytest
 
-from detect_secrets_server.usage import ServerParserBuilder
 from detect_secrets_server.hooks.external import ExternalHook
 from detect_secrets_server.hooks.pysensu_yelp import PySensuYelpHook
+from detect_secrets_server.usage import ServerParserBuilder
 
 
 class TestOutputOptions(object):
@@ -29,7 +29,7 @@ class TestOutputOptions(object):
     def test_invalid_output_hook(self, hook_input):
         with pytest.raises(SystemExit):
             self.parse_args('--output-hook {}'.format(hook_input))
- 
+
     @pytest.mark.parametrize(
         'hook_input,instance_type',
         [
@@ -37,7 +37,7 @@ class TestOutputOptions(object):
                 # For testing purposes, the exact config does not
                 # matter; it just needs to be yaml loadable.
                 'pysensu --output-config repos.yaml.sample',
-                PySensuYelpHook,                
+                PySensuYelpHook,
             ),
             (
                 'setup.py',
@@ -52,3 +52,16 @@ class TestOutputOptions(object):
         with pytest.raises(AttributeError):
             getattr(args, 'output_config')
 
+    @pytest.mark.parametrize(
+        'action_flag',
+        [
+            '--initialize',
+            '--scan-repo does_not_matter',
+        ]
+    )
+    def test_actions_requires_output_hook(self, action_flag):
+        with pytest.raises(SystemExit):
+            self.parse_args(action_flag)
+
+        args = self.parse_args('{} --output-hook setup.py'.format(action_flag))
+        assert args.output_hook_command == '--output-hook setup.py'


### PR DESCRIPTION
New help screen.

```
usage: detect_secrets_server [-h] [--base64-limit BASE64_LIMIT]
                             [--hex-limit HEX_LIMIT] [--no-hex-string-scan]
                             [--no-base64-string-scan] [--no-private-key-scan]
                             [-v] [--initialize [CUSTOM_REPO_CONFIG_FILE]]
                             [--scan-repo REPO_TO_SCAN]
                             [--config-file CONFIG_FILE]
                             [--add-repo REPO_TO_ADD] [-L]
                             [--s3-config-file S3_CONFIG_FILE]
                             [--baseline BASELINE] [--output-hook HOOK]
                             [--output-config CONFIG_FILENAME]

...

output:
  Configure output method, for alerting upon secrets found in tracked
  repository.

  --output-hook HOOK    Either one of the pre-registered hooks (pysensu) or a
                        path to a valid executable file.
  --output-config CONFIG_FILENAME
                        Configuration file to initialize output hook, if
                        required.
```

New usage.

```
$ detect-secrets-server --output-hook pysensu --output-config .pysensu.config.yaml.sample
```

OR

```
$ cat tmp/hook.py
import sys

print('repo name', sys.argv[1])
print('secrets found')
print(json.dumps(json.loads(sys.argv[2]), indent=2))
$ detect-secrets-server --output-hook tmp/hook.py
```