### PR TITLE
Adding `--always-update-state` flag.

### DIFF
--- a/detect_secrets_server/actions/scan.py
+++ b/detect_secrets_server/actions/scan.py
@@ -30,7 +30,10 @@ def scan_repo(args):
 
     if len(secrets.data) > 0:
         _alert_on_secrets_found(repo, secrets.json(), args.output_hook)
-    elif not args.dry_run:
+
+    if args.always_update_state or (
+        len(secrets.data) == 0 and not args.dry_run
+    ):
         _update_tracked_repo(repo)
 
     return 0

--- a/detect_secrets_server/core/usage/scan.py
+++ b/detect_secrets_server/core/usage/scan.py
@@ -35,8 +35,8 @@ class ScanOptions(CommonOptions):
             '--always-update-state',
             action='store_true',
             help=(
-                'Always update the internal tracking state after a successful scan, '
-                'despite finding secrets.'
+                'Always update the internal tracking state (latest commit scanned) '
+                'after a successful scan, despite finding secrets.'
             ),
         )
 

--- a/detect_secrets_server/core/usage/scan.py
+++ b/detect_secrets_server/core/usage/scan.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 
 from detect_secrets.core.usage import PluginOptions
@@ -30,6 +31,14 @@ class ScanOptions(CommonOptions):
                 'saving state.'
             ),
         )
+        self.parser.add_argument(
+            '--always-update-state',
+            action='store_true',
+            help=(
+                'Always update the internal tracking state after a successful scan, '
+                'despite finding secrets.'
+            ),
+        )
 
         self.add_local_flag()
         for option in [PluginOptions, OutputOptions]:
@@ -40,6 +49,11 @@ class ScanOptions(CommonOptions):
     @staticmethod
     def consolidate_args(args):
         """Validation and appropriate formatting of args.repo"""
+        if args.dry_run and args.always_update_state:
+            raise argparse.ArgumentTypeError(
+                'Can\'t use --dry-run with --always-update-state.',
+            )
+
         for option in [CommonOptions, OutputOptions]:
             option.consolidate_args(args)
 

--- a/tests/actions/scan_test.py
+++ b/tests/actions/scan_test.py
@@ -33,21 +33,6 @@ class TestScanRepo(object):
                 (base_argument + argument_string).split()
             )
 
-    @contextmanager
-    def setup_env(self, scan_results, argument_string=''):
-        """This sets up the relevant mocks, so that we can conduct testing."""
-        args = self.parse_args(argument_string)
-
-        with mock.patch(
-            'detect_secrets_server.repos.base_tracked_repo.BaseTrackedRepo.scan',
-            return_value=scan_results,
-        ), mock.patch(
-            # We mock this, so that we can successfully load_from_file
-            'detect_secrets_server.storage.file.FileStorage.get',
-            return_value=mock_tracked_file('old_sha'),
-        ):
-            yield args
-
     def test_quits_early_if_cannot_load_meta_tracking_file(self):
         args = self.parse_args()
 
@@ -58,15 +43,10 @@ class TestScanRepo(object):
         mock_file_operations,
         mock_logger
     ):
-        # mock_git_calls is used for repo.update
         with self.setup_env(
-            SecretsCollection()
-        ) as args, mock_git_calls(
-            SubprocessMock(
-                expected_input='git rev-parse HEAD',
-                mocked_output='new_sha',
-            ),
-        ):
+            SecretsCollection(),
+            updates_repo=True,
+        ) as args:
             assert scan_repo(args) == 0
 
         mock_logger.info.assert_called_with(
@@ -90,24 +70,7 @@ class TestScanRepo(object):
             },
         ])
 
-        with self.setup_env(
-            secrets,
-        ) as args, mock_git_calls(
-            # First, we get the main branch
-            SubprocessMock(
-                expected_input='git rev-parse --abbrev-ref HEAD',
-                mocked_output='master',
-            ),
-
-            # then, we get the blame info for that branch.
-            SubprocessMock(
-                expected_input=(
-                    'git blame master -L 5,5 --show-email '
-                    '--line-porcelain -- file_with_secrets'
-                ),
-                mocked_output=mock_blame_info(),
-            ),
-        ):
+        with self.setup_env(secrets) as args:
             secret_hash = list(
                 secrets.data['file_with_secrets'].values()
             )[0].secret_hash
@@ -140,6 +103,107 @@ class TestScanRepo(object):
             assert scan_repo(args) == 0
 
         assert not mock_file_operations.write.called
+
+    def test_always_writes_state_with_always_update_state_flag(
+        self,
+        mock_file_operations,
+    ):
+        secrets = secrets_collection_factory([
+            {
+                'filename': 'file_with_secrets',
+                'lineno': 5,
+            },
+        ])
+
+        with self.setup_env(
+            secrets,
+            '--always-update-state',
+            updates_repo=True,
+        ) as args:
+            assert scan_repo(args) == 0
+
+        assert mock_file_operations.write.called
+
+    @contextmanager
+    def setup_env(self, scan_results, argument_string='', updates_repo=False):
+        """This sets up the relevant mocks, so that we can conduct testing.
+
+        :type scan_results: SecretsCollection
+
+        :type argument_string: str
+        :param argument_string: additional arguments to parse_args
+
+        :type updates_repo: bool
+        :param updates_repo: True if scan should update its internal state
+        """
+        @contextmanager
+        def wrapped_mock_git_calls(git_calls):
+            if not git_calls:
+                # Need to yield **something**
+                yield
+                return
+
+            with mock_git_calls(*git_calls):
+                yield
+
+        args = self.parse_args(argument_string)
+
+        with mock.patch(
+            'detect_secrets_server.repos.base_tracked_repo.BaseTrackedRepo.scan',
+            return_value=scan_results,
+        ), mock.patch(
+            # We mock this, so that we can successfully load_from_file
+            'detect_secrets_server.storage.file.FileStorage.get',
+            return_value=mock_tracked_file('old_sha'),
+        ), wrapped_mock_git_calls(
+            get_subprocess_mocks(scan_results, updates_repo),
+        ):
+            yield args
+
+
+def get_subprocess_mocks(secrets, updates_repo):
+    """
+    :type secrets: SecretsCollection
+    :type updates_repo: bool
+    """
+    subprocess_mocks = []
+    if secrets.data:
+        # TODO: If we need to, we should modify this for more filenames
+        secrets_dict = secrets.json()
+        filenames = list(secrets_dict.keys())
+
+        subprocess_mocks.append(
+            # First, we get the main branch
+            SubprocessMock(
+                expected_input='git rev-parse --abbrev-ref HEAD',
+                mocked_output='master',
+            ),
+        )
+
+        subprocess_mocks.append(
+            # then, we get the blame info for that branch.
+            SubprocessMock(
+                expected_input=(
+                    'git blame master -L {},{} --show-email '
+                    '--line-porcelain -- {}'.format(
+                        secrets_dict[filenames[0]][0]['line_number'],
+                        secrets_dict[filenames[0]][0]['line_number'],
+                        filenames[0],
+                    )
+                ),
+                mocked_output=mock_blame_info(),
+            ),
+        )
+
+    if updates_repo:
+        subprocess_mocks.append(
+            SubprocessMock(
+                expected_input='git rev-parse HEAD',
+                mocked_output='new_sha',
+            ),
+        )
+
+    return subprocess_mocks
 
 
 def mock_tracked_file(sha):

--- a/tests/core/usage/scan_test.py
+++ b/tests/core/usage/scan_test.py
@@ -18,3 +18,12 @@ class TestScanOptions(UsageTest):
         assert args.action == 'scan'
         assert args.local
         assert isinstance(args.output_hook, ExternalHook)
+
+    def test_conflicting_args(self):
+        with pytest.raises(SystemExit):
+            self.parse_args(
+                'scan'
+                ' --dry-run --always-update-state'
+                ' -L examples'
+                ' --output-hook examples/standalone_hook.py'
+            )


### PR DESCRIPTION
Fixes https://github.com/Yelp/detect-secrets-server/issues/8.

This flag allows users to delegate state management to the output-hook. This is because state will **always** be updated, despite finding secrets, so output-hooks are trusted to keep track of which secrets to alert on.