### PR TITLE
Adding --diff-filter optimization

### DIFF
--- a/detect_secrets_server/storage/core/git.py
+++ b/detect_secrets_server/storage/core/git.py
@@ -136,6 +136,7 @@ def _filter_filenames_from_diff(directory, last_commit_hash):
         last_commit_hash,
         'HEAD',
         '--name-only',
+        '--diff-filter', 'ACM',
     ).splitlines()
 
     return [

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -113,7 +113,7 @@ class TestMain(object):
             ),
             # Getting relevant diff
             SubprocessMock(
-                expected_input='git diff {} HEAD --name-only'.format(mocked_sha),
+                expected_input='git diff {} HEAD --name-only --diff-filter ACM'.format(mocked_sha),
                 mocked_output='filenameA',
             ),
             SubprocessMock(

--- a/tests/repos/base_tracked_repo_test.py
+++ b/tests/repos/base_tracked_repo_test.py
@@ -213,7 +213,7 @@ class TestScan(object):
 
             # get diff (filtering out ignored file extensions)
             SubprocessMock(
-                expected_input='git diff sha256-hash HEAD --name-only',
+                expected_input='git diff sha256-hash HEAD --name-only --diff-filter ACM',
                 mocked_output='examples/aws_credentials.json',
             ),
             SubprocessMock(


### PR DESCRIPTION
We don't care about **all** files that are included in a git diff (e.g.
renamed files, deleted files). This optimization will only list the
files that we care about, to improve performance.

### Chosen filters

A: Added
C: Copied
M: Modified

### Ignored filters

D: **Deleted** - if the file is gone, do we really care?
R: **Renamed** - we're only scanning diffs, so a filename difference doesn't matter
T: **Changed** type (e.g. regular file -> symlink) - this won't add new secrets
U: **Unmerged** - this won't add new secrets
X: **Unknown** - no idea what to do with this.
B: **Broken** pairing - no idea what to do with this.
