### PR TITLE
Replacing git pull with git fetch

### DIFF
--- a/detect_secrets_server/actions/initialize.py
+++ b/detect_secrets_server/actions/initialize.py
@@ -122,7 +122,7 @@ def _clone_and_save_repo(repo):
     :param repo: repo to clone (if appropriate) and save
     """
     # Clone repo, if needed.
-    repo.storage.clone_and_pull_master()
+    repo.storage.clone()
 
     # Make the last_commit_hash of repo point to HEAD
     if not repo.last_commit_hash:

--- a/detect_secrets_server/repos/base_tracked_repo.py
+++ b/detect_secrets_server/repos/base_tracked_repo.py
@@ -115,7 +115,7 @@ class BaseTrackedRepo(object):
         return self.storage.repository_name
 
     def scan(self, exclude_files_regex=None, exclude_lines_regex=None):
-        """Clones the repo, and scans the git diff between last_commit_hash
+        """Fetches latest changes, and scans the git diff between last_commit_hash
         and HEAD.
 
         :raises: subprocess.CalledProcessError
@@ -129,7 +129,7 @@ class BaseTrackedRepo(object):
         :rtype: SecretsCollection
         :returns: secrets found.
         """
-        self.storage.clone_and_pull_master()
+        self.storage.fetch_new_changes()
 
         default_plugins = initialize_plugins.from_parser_builder(
             self.plugin_config,

--- a/detect_secrets_server/storage/base.py
+++ b/detect_secrets_server/storage/base.py
@@ -74,13 +74,14 @@ class BaseStorage(object):
         """Human friendly name of git repository tracked."""
         return self.get_repo_name(self.repo_url)
 
-    def clone_and_pull_master(self):
+    def clone(self):
         git.clone_repo_to_location(
             self.repo_url,
             self._repo_location,
         )
 
-        git.pull_master(self._repo_location)
+    def fetch_new_changes(self):
+        git.fetch_new_changes(self._repo_location)
 
     def get_diff(self, from_sha):
         try:
@@ -212,7 +213,7 @@ class LocalGitRepository(BaseStorage):
             git.get_remote_url(path),
         )
 
-    def clone_and_pull_master(self):
+    def clone(self):
         """The assumption is, if you are scanning a local git repository,
         then you are "actively" working on it. Therefore, this module will
         not bear the responsibility of auto-updating the repo with `git pull`.

--- a/detect_secrets_server/storage/core/git.py
+++ b/detect_secrets_server/storage/core/git.py
@@ -48,10 +48,13 @@ def clone_repo_to_location(repo, directory):
             raise
 
 
-def pull_master(directory):
+def fetch_new_changes(directory):
     _git(
         directory,
-        'pull',
+        'fetch',
+        '--quiet',
+        'origin',
+        _get_main_branch(directory),
     )
 
 

--- a/tests/actions/initialize_test.py
+++ b/tests/actions/initialize_test.py
@@ -239,9 +239,6 @@ class TestAddRepo(object):
                 expected_input='git clone {} {} --bare'.format(repo, directory),
             ),
             SubprocessMock(
-                expected_input='git pull',
-            ),
-            SubprocessMock(
                 expected_input='git rev-parse HEAD',
                 mocked_output='mocked_sha',
             ),

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -85,9 +85,6 @@ class TestMain(object):
                     directory,
                 ),
             ),
-            SubprocessMock(
-                expected_input='git pull',
-            ),
             # Since there is no prior sha to retrieve
             SubprocessMock(
                 expected_input='git rev-parse HEAD',
@@ -102,14 +99,11 @@ class TestMain(object):
         with mock_git_calls(
             # Getting latest changes
             SubprocessMock(
-                expected_input=(
-                    'git clone https://github.com/Yelp/detect-secrets {} --bare'
-                ).format(
-                    directory,
-                ),
+                expected_input='git rev-parse --abbrev-ref HEAD',
+                mocked_output='master',
             ),
             SubprocessMock(
-                expected_input='git pull',
+                expected_input='git fetch --quiet origin master',
             ),
             # Getting relevant diff
             SubprocessMock(

--- a/tests/repos/base_tracked_repo_test.py
+++ b/tests/repos/base_tracked_repo_test.py
@@ -190,25 +190,17 @@ class TestScan(object):
         """We need to do a bunch of mocking, because there's a lot of git
         operations. This function handles all that.
         """
-        tracked_location = '{}/repos/{}'.format(
-            mock_rootdir,
-            FileStorage.hash_filename('yelp/detect-secrets'),
-        )
-
         with open('test_data/sample.diff') as f:
             diff_content = f.read()
 
         return [
-            # clone and pull master
+            # fetching latest changes
             SubprocessMock(
-                expected_input=(
-                    'git clone git@github.com:yelp/detect-secrets {} --bare'.format(
-                        tracked_location,
-                    )
-                ),
+                expected_input='git rev-parse --abbrev-ref HEAD',
+                mocked_output='master',
             ),
             SubprocessMock(
-                expected_input='git pull',
+                expected_input='git fetch --quiet origin master',
             ),
 
             # get diff (filtering out ignored file extensions)

--- a/tests/storage/base_test.py
+++ b/tests/storage/base_test.py
@@ -79,11 +79,8 @@ class TestBaseStorage(object):
                 b'fatal: destination path \'blah\' already exists',
                 mock_rootdir,
             ),
-            SubprocessMock(
-                expected_input='git pull',
-            ),
         ):
-            repo.clone_and_pull_master()
+            repo.clone()
 
     def test_clone_repo_something_else_went_wrong(self, mock_rootdir, base_storage):
         with assert_directories_created():
@@ -98,7 +95,7 @@ class TestBaseStorage(object):
         ), pytest.raises(
             subprocess.CalledProcessError
         ):
-            repo.clone_and_pull_master()
+            repo.clone()
 
     @staticmethod
     def construct_subprocess_mock_git_clone(repo, mocked_output, mock_rootdir):
@@ -144,11 +141,11 @@ class TestLocalGitRepository(object):
         ), assert_directories_created():
             assert local_storage.setup(repo).repository_name == name
 
-    def test_clone_and_pull_master(self, local_storage):
+    def test_clone(self, local_storage):
         # We're asserting that nothing is run in this case.
         with mock_git_calls(), assert_directories_created():
             local_storage.setup('git@github.com:yelp/detect-secrets')\
-                .clone_and_pull_master()
+                .clone()
 
 
 class TestGetFilepathSafe(object):


### PR DESCRIPTION
Addresses https://github.com/Yelp/detect-secrets-server/issues/21

Couple of points to note:

* `scan` no longer clones repositories.
I think this is fine, because [scan fails if it can't find the metadata file](https://github.com/Yelp/detect-secrets-server/blob/master/detect_secrets_server/actions/scan.py#L25) from `add`. The only situation where I think this would be an issue is if the added bare repository was removed between `add` and `scan`. Seems like a strange situation to be in, even with local repositories.

* `clone` no longer pulls master.
The only time when clone needs to also pull master is if you're cloning a repository you're already tracking. But since pull doesn't do anything with bare repositories (and it doesn't even pull locally managed repositories), this seems redundant.