### PR TITLE
Fix commit attribute of secrets to be current HEAD

### DIFF
--- a/detect_secrets_server/actions/scan.py
+++ b/detect_secrets_server/actions/scan.py
@@ -64,16 +64,15 @@ def _alert_on_secrets_found(repo, secrets, output_hook):
     """
     log.error('Secrets found in %s', repo.name)
 
-    _set_authors_and_commits_for_found_secrets(repo, secrets)
+    _set_authors_for_found_secrets(repo, secrets)
 
     output_hook.alert(repo.name, secrets)
 
 
-def _set_authors_and_commits_for_found_secrets(repo, secrets):
+def _set_authors_for_found_secrets(repo, secrets):
     """Use git blame to try and identify the user who committed the
-    potential secret, and the commit. This allows us to follow up
-    with a specific user if a secret is found, and reference the
-    exact commit that caused the alert.
+    potential secret. This allows us to follow up with a specific user if
+    a secret is found.
 
     Modifies secrets in-place.
     """
@@ -83,33 +82,22 @@ def _set_authors_and_commits_for_found_secrets(repo, secrets):
                 filename,
                 potential_secret_dict['line_number'],
             )
-            author, commit = (
-                _extract_author_and_commit_from_git_blame_info(blame_info)
-            )
-            potential_secret_dict['author'] = author
-            potential_secret_dict['commit'] = commit
+
+            potential_secret_dict['author'] = \
+                _extract_user_from_git_blame_info(blame_info)
 
 
-def _extract_author_and_commit_from_git_blame_info(blame_info):
+def _extract_user_from_git_blame_info(info):
     """As this tool is meant to be used in an enterprise setting, we assume
     that the email address of the committer uniquely identifies a given user.
 
-    :type blame_info: str
-    :param blame_info: output of `git blame` from git.py
-
-    :rtype: tuple(str, str)
-    :returns: author from author-mail and commit hash
+    This function extracts that information.
     """
-    blame_info = blame_info.split()
+    info = info.split()
 
-    # e.g. b5ce07a9b1a616330c1bf33799b6d06d1f9c6336 8 10 1
-    commit_line = blame_info[0]
-    commit_hash = commit_line.split()[0]
-
-    index_of_mail = blame_info.index('author-mail')
-    email = blame_info[index_of_mail + 1]  # e.g. `<khock@yelp.com>`
+    index_of_mail = info.index('author-mail')
+    email = info[index_of_mail + 1]     # Eg. `<khock@yelp.com>`
     index_of_at_symbol = email.index('@')
-    # This will skip the prefix `<`, and extract the user up to the `@` sign.
-    author = email[1:index_of_at_symbol]
 
-    return author, commit_hash
+    # This will skip the prefix `<`, and extract the user up to the `@` sign.
+    return email[1:index_of_at_symbol]

--- a/detect_secrets_server/actions/scan.py
+++ b/detect_secrets_server/actions/scan.py
@@ -82,9 +82,11 @@ def _set_authors_for_found_secrets(repo, secrets):
                 filename,
                 potential_secret_dict['line_number'],
             )
-
-            potential_secret_dict['author'] = \
+            potential_secret_dict['author'] = (
                 _extract_user_from_git_blame_info(blame_info)
+            )
+            # Set commit as current head when found, not when secret was added
+            potential_secret_dict['commit'] = repo.storage.get_last_commit_hash()
 
 
 def _extract_user_from_git_blame_info(info):

--- a/detect_secrets_server/repos/base_tracked_repo.py
+++ b/detect_secrets_server/repos/base_tracked_repo.py
@@ -171,7 +171,6 @@ class BaseTrackedRepo(object):
 
         :type override_level: OverrideLevel
         :param override_level: determines if we overwrite the JSON file, if exists.
-
         :rtype: bool
         :returns: True if repository is saved.
         """

--- a/detect_secrets_server/repos/base_tracked_repo.py
+++ b/detect_secrets_server/repos/base_tracked_repo.py
@@ -171,6 +171,7 @@ class BaseTrackedRepo(object):
 
         :type override_level: OverrideLevel
         :param override_level: determines if we overwrite the JSON file, if exists.
+
         :rtype: bool
         :returns: True if repository is saved.
         """

--- a/tests/actions/scan_test.py
+++ b/tests/actions/scan_test.py
@@ -83,6 +83,7 @@ class TestScanRepo(object):
                         'hashed_secret': secret_hash,
                         'line_number': 5,
                         'author': 'khock',
+                        'commit': 'new_sha',
                     }],
                 },
             )
@@ -181,7 +182,7 @@ def get_subprocess_mocks(secrets, updates_repo):
         )
 
         subprocess_mocks.append(
-            # then, we get the blame info for that branch.
+            # then, we get the blame info for that branch
             SubprocessMock(
                 expected_input=(
                     'git blame master -L {},{} --show-email '
@@ -195,7 +196,16 @@ def get_subprocess_mocks(secrets, updates_repo):
             ),
         )
 
+        subprocess_mocks.append(
+            # and get the current HEAD.
+            SubprocessMock(
+                expected_input='git rev-parse HEAD',
+                mocked_output='new_sha',
+            ),
+        )
+
     if updates_repo:
+        # We also get the current HEAD when updating.
         subprocess_mocks.append(
             SubprocessMock(
                 expected_input='git rev-parse HEAD',

--- a/tests/actions/scan_test.py
+++ b/tests/actions/scan_test.py
@@ -83,7 +83,6 @@ class TestScanRepo(object):
                         'hashed_secret': secret_hash,
                         'line_number': 5,
                         'author': 'khock',
-                        'commit': 'd39c008353447bbc1845812fcaf0a03b50af439f',
                     }],
                 },
             )


### PR DESCRIPTION
In scan.py, we [called `_set_authors_and_commits_for_found_secrets`](https://github.com/Yelp/detect-secrets-server/commit/505e79100a776237e96cc1c22a65d80fe99c7795). We mistakenly used the commit from the blamed line, instead of the current HEAD.

This caused a mismatch between the line number (from the current HEAD) and the commit (it was not the current HEAD, but when the secret line was last touched.)

This changes things so we add the commit of the current HEAD when the secret is found.