### PR TITLE
Fix fetching on bare repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 matrix:
     include:
         - env: TOXENV=py27
+          python: 2.7
         - env: TOXENV=py35
           python: 3.5
         - env: TOXENV=py36

--- a/detect_secrets_server/storage/core/git.py
+++ b/detect_secrets_server/storage/core/git.py
@@ -59,6 +59,7 @@ def fetch_new_changes(directory):
             main_branch,
             main_branch,
         ),
+        '--force',
     )
 
 

--- a/detect_secrets_server/storage/core/git.py
+++ b/detect_secrets_server/storage/core/git.py
@@ -49,12 +49,16 @@ def clone_repo_to_location(repo, directory):
 
 
 def fetch_new_changes(directory):
+    main_branch = _get_main_branch(directory)
     _git(
         directory,
         'fetch',
         '--quiet',
         'origin',
-        _get_main_branch(directory),
+        '{}:{}'.format(
+            main_branch,
+            main_branch,
+        ),
     )
 
 
@@ -154,10 +158,6 @@ def _git(directory, *args):
         [
             'git',
             '--git-dir', directory,
-
-            # Work-tree is required for some git commands, because of bare repos.
-            # However, it doesn't hurt to put it for all of them.
-            '--work-tree', '.',
         ] + list(args),
         stderr=subprocess.STDOUT
     )

--- a/testing/mocks.py
+++ b/testing/mocks.py
@@ -70,7 +70,7 @@ def mock_git_calls(*cases):
 
         return case.mocked_output
 
-    def _mock_single_git_call(directory, *args):
+    def _mock_single_git_call(directory, *args, **kwargs):
         return _mock_subprocess_git_call(['git'] + list(args))
 
     # mock_subprocess is needed for `clone_repo_to_location`.

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -103,7 +103,7 @@ class TestMain(object):
                 mocked_output='master',
             ),
             SubprocessMock(
-                expected_input='git fetch --quiet origin master',
+                expected_input='git fetch --quiet origin master:master',
             ),
             # Getting relevant diff
             SubprocessMock(

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -103,7 +103,7 @@ class TestMain(object):
                 mocked_output='master',
             ),
             SubprocessMock(
-                expected_input='git fetch --quiet origin master:master',
+                expected_input='git fetch --quiet origin master:master --force',
             ),
             # Getting relevant diff
             SubprocessMock(

--- a/tests/repos/base_tracked_repo_test.py
+++ b/tests/repos/base_tracked_repo_test.py
@@ -200,7 +200,7 @@ class TestScan(object):
                 mocked_output='master',
             ),
             SubprocessMock(
-                expected_input='git fetch --quiet origin master',
+                expected_input='git fetch --quiet origin master:master',
             ),
 
             # get diff (filtering out ignored file extensions)

--- a/tests/repos/base_tracked_repo_test.py
+++ b/tests/repos/base_tracked_repo_test.py
@@ -200,7 +200,7 @@ class TestScan(object):
                 mocked_output='master',
             ),
             SubprocessMock(
-                expected_input='git fetch --quiet origin master:master',
+                expected_input='git fetch --quiet origin master:master --force',
             ),
 
             # get diff (filtering out ignored file extensions)


### PR DESCRIPTION
See commit messages and https://github.com/Yelp/detect-secrets-server/issues/29 for more info. https://stackoverflow.com/questions/50626560/git-fetch-non-fast-forward-update gives a good explainer of why we were only updating `FETCH_HEAD` with the original code of `git fetch origin master` rather than `master:master`.

Also fixed a `unidiff` issue (https://github.com/matiasb/python-unidiff/issues/54) that @guykisel helpfully fixed in their repository (https://github.com/guykisel/inline-plz/pull/227/files)