### PR TITLE
adding --always-run-output-hook flag

### DIFF
--- a/detect_secrets_server/actions/scan.py
+++ b/detect_secrets_server/actions/scan.py
@@ -31,7 +31,7 @@ def scan_repo(args):
         exclude_lines_regex=args.exclude_lines,
     )
 
-    if len(secrets.data) > 0:
+    if (len(secrets.data) > 0) or (args.always_run_output_hook):
         _alert_on_secrets_found(repo, secrets.json(), args.output_hook)
 
     if args.always_update_state or (

--- a/detect_secrets_server/core/usage/scan.py
+++ b/detect_secrets_server/core/usage/scan.py
@@ -59,6 +59,15 @@ class ScanOptions(CommonOptions):
             metavar='REGEX',
         )
 
+        self.parser.add_argument(
+            '--always-run-output-hook',
+            action='store_true',
+            help=(
+                'Always run the output hook, even if no issues have been found.'
+                'must be run with the --output-hook option'
+            ),
+        )
+
         self.add_local_flag()
         for option in [PluginOptions, OutputOptions]:
             option(self.parser).add_arguments()
@@ -71,6 +80,10 @@ class ScanOptions(CommonOptions):
         if args.dry_run and args.always_update_state:
             raise argparse.ArgumentTypeError(
                 'Can\'t use --dry-run with --always-update-state.',
+            )
+        if (args.always_run_output_hook and (None is args.output_hook)):
+           raise argparse.ArgumentTypeError(
+                    '--always-run-output-hook must be run with --output-hook',
             )
 
         for option in [CommonOptions, OutputOptions]:

--- a/detect_secrets_server/core/usage/scan.py
+++ b/detect_secrets_server/core/usage/scan.py
@@ -82,8 +82,8 @@ class ScanOptions(CommonOptions):
                 'Can\'t use --dry-run with --always-update-state.',
             )
         if (args.always_run_output_hook and (None is args.output_hook)):
-           raise argparse.ArgumentTypeError(
-                    '--always-run-output-hook must be run with --output-hook',
+            raise argparse.ArgumentTypeError(
+                '--always-run-output-hook must be run with --output-hook',
             )
 
         for option in [CommonOptions, OutputOptions]:


### PR DESCRIPTION
This is pretty much my first attempt at a pull request on github.com. Please let me know if something went wrong.

This simply adds the "--always-run-output-hook" flag. I have tested it on a fresh VM, and it seems to work. The "make test" option did show a few errors, but that was due to not having various versions of python installed. I tested against 2.7 and 3.7 on centos 7. 

Thank you. 

...and please do let me know if I did something wrong.