### PR TITLE
:bug: Fix `Argument list too long` error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@
     -   id: name-tests-test
         exclude: tests/util
     -   id: flake8
-        args: ['--ignore=E501']
+        args: ['--ignore=E501,W503,W504']
 -   repo: https://github.com/asottile/reorder_python_imports
     sha: v0.3.5
     hooks:


### PR DESCRIPTION
Note that this will cause us to scan files we should not
but hopefully those are not included in the special case of a giant diff.