### PR TITLE
Handle empty git repos 

### DIFF
--- a/detect_secrets_server/actions/initialize.py
+++ b/detect_secrets_server/actions/initialize.py
@@ -129,4 +129,4 @@ def _clone_and_save_repo(repo):
         repo.update()
 
     # Save the last_commit_hash, if we have nothing on file already
-    return repo.save(OverrideLevel.NEVER)
+    return repo.save(OverrideLevel.ALWAYS)

--- a/detect_secrets_server/actions/initialize.py
+++ b/detect_secrets_server/actions/initialize.py
@@ -127,6 +127,7 @@ def _clone_and_save_repo(repo):
     # Make the last_commit_hash of repo point to HEAD
     if not repo.last_commit_hash:
         repo.update()
+        return repo.save(OverrideLevel.ALWAYS)
 
     # Save the last_commit_hash, if we have nothing on file already
-    return repo.save(OverrideLevel.ALWAYS)
+    return repo.save(OverrideLevel.NEVER)

--- a/detect_secrets_server/actions/scan.py
+++ b/detect_secrets_server/actions/scan.py
@@ -4,6 +4,7 @@ from detect_secrets.core.log import log
 
 from detect_secrets_server.repos.base_tracked_repo import OverrideLevel
 from detect_secrets_server.repos.factory import tracked_repo_factory
+from detect_secrets_server.actions.initialize import _clone_and_save_repo
 
 try:
     FileNotFoundError
@@ -25,6 +26,10 @@ def scan_repo(args):
     except FileNotFoundError:
         log.error('Unable to find repo: %s', args.repo)
         return 1
+
+    # if last_commit_hash is empty, go ahead and try to reinitalize to see if there's a new base hash
+    if repo.last_commit_hash is None:
+        _clone_and_save_repo(repo)
 
     secrets = repo.scan(
         exclude_files_regex=args.exclude_files,

--- a/detect_secrets_server/actions/scan.py
+++ b/detect_secrets_server/actions/scan.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import
 
 from detect_secrets.core.log import log
 
+from detect_secrets_server.actions.initialize import _clone_and_save_repo
 from detect_secrets_server.repos.base_tracked_repo import OverrideLevel
 from detect_secrets_server.repos.factory import tracked_repo_factory
-from detect_secrets_server.actions.initialize import _clone_and_save_repo
 
 try:
     FileNotFoundError

--- a/detect_secrets_server/actions/scan.py
+++ b/detect_secrets_server/actions/scan.py
@@ -27,7 +27,7 @@ def scan_repo(args):
         log.error('Unable to find repo: %s', args.repo)
         return 1
 
-    # if last_commit_hash is empty, go ahead and try to reinitalize to see if there's a new base hash
+    # if last_commit_hash is empty, re-clone and see if there's an initial commit hash
     if repo.last_commit_hash is None:
         _clone_and_save_repo(repo)
 

--- a/tests/actions/initialize_test.py
+++ b/tests/actions/initialize_test.py
@@ -224,7 +224,7 @@ class TestAddRepo(object):
             ),
         )
 
-    def test_never_override_meta_tracking_if_already_exists(
+    def test_override_meta_tracking_if_already_exists(
         self,
         mock_file_operations,
         mock_rootdir,
@@ -237,7 +237,7 @@ class TestAddRepo(object):
         ):
             self.add_non_local_repo(mock_rootdir)
 
-        assert not mock_file_operations.write.called
+        assert mock_file_operations.write.called
 
     def add_non_local_repo(self, mock_rootdir):
         repo = 'git@github.com:yelp/detect-secrets'


### PR DESCRIPTION
Addresses Issue #19 

Two changes: 

1. Add exception catching for _git() for two scenarios: A) initial add (fails on getting HEAD) and B) scan with empty commit hashes
2. Add code to handle scanning an empty repo and update said repo if it does flip to non-empty in `scan.py`. This also required a change in `_clone_and_save_repo()` to allow an update to existing metadata. 

Unintended side effect was having to change the test case for existing metadata. I flipped it to testing for allowing update because my mocking blows and I couldn't figure out how to easily add a `repo.last_commit_hash` so it wouldn't take the empty repo path. 
 
