### PR TITLE
Feature Extract pragmas

### DIFF
--- a/detect_secrets_server/core/usage/scan.py
+++ b/detect_secrets_server/core/usage/scan.py
@@ -86,6 +86,17 @@ class ScanOptions(CommonOptions):
             ),
         )
 
+        self.parser.add_argument(
+            '--custom-plugins',
+            type=str,
+            default=(),
+            dest='custom_plugin_paths',
+            help=(
+                'Custom plugin Python files, or directories containing them. '
+                'Directories are not searched recursively.'
+            ),
+        )
+
         self.add_local_flag()
         for option in [PluginOptions, OutputOptions]:
             option(self.parser).add_arguments()

--- a/detect_secrets_server/core/usage/scan.py
+++ b/detect_secrets_server/core/usage/scan.py
@@ -77,6 +77,15 @@ class ScanOptions(CommonOptions):
             ),
         )
 
+        self.parser.add_argument(
+            '--extract-pragmas',
+            action='store_true',
+            help=(
+                'Extract "pragma: allowlist secret" lines from the code, '
+                'and output the report as json.'
+            ),
+        )
+
         self.add_local_flag()
         for option in [PluginOptions, OutputOptions]:
             option(self.parser).add_arguments()

--- a/detect_secrets_server/hooks/base.py
+++ b/detect_secrets_server/hooks/base.py
@@ -11,12 +11,15 @@ class BaseHook(object):  # pragma: no cover
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def alert(self, repo_name, secrets):
+    def alert(self, repo_name, secrets, pragmas=None):
         """
         :type repo_name: str
         :param repo_name: the repository where secrets were found.
 
         :type secrets: dict
         :param secrets: dictionary; where keys are filenames
+
+        :type pragmas: dict (optional)
+        :param pragmas: dictionary; where keys are filenames
         """
         pass

--- a/detect_secrets_server/hooks/stdout.py
+++ b/detect_secrets_server/hooks/stdout.py
@@ -8,8 +8,9 @@ from .base import BaseHook
 
 class StdoutHook(BaseHook):
 
-    def alert(self, repo_name, secrets):
+    def alert(self, repo_name, secrets, pragmas=None):
         print(json.dumps({
             'repo': repo_name,
             'output': secrets,
+            'pragmas': pragmas,
         }))

--- a/detect_secrets_server/repos/base_tracked_repo.py
+++ b/detect_secrets_server/repos/base_tracked_repo.py
@@ -113,7 +113,7 @@ class BaseTrackedRepo(object):
     def name(self):
         return self.storage.repository_name
 
-    def scan(self, exclude_files_regex=None, exclude_lines_regex=None, scan_head=False):
+    def scan(self, exclude_files_regex=None, exclude_lines_regex=None, scan_head=False, extract_pragmas=False, custom_plugin_paths=()):
         """Fetches latest changes, and scans the git diff between last_commit_hash
         and HEAD.
 
@@ -125,6 +125,12 @@ class BaseTrackedRepo(object):
         :type exclude_lines: str|None
         :param exclude_lines: A regex matching lines to skip over.
 
+        :type scan_head: bool
+        :param scan_head: Enable scan head context.
+
+        :type extract_pragmas: bool
+        :param extract_pragmas: Enable extract pragmas feature.
+
         :rtype: SecretsCollection
         :returns: secrets found.
         """
@@ -132,6 +138,7 @@ class BaseTrackedRepo(object):
 
         default_plugins = initialize_plugins.from_parser_builder(
             self.plugin_config,
+            custom_plugin_paths=custom_plugin_paths,
             exclude_lines_regex=exclude_lines_regex,
         )
         # TODO Issue 17: Ignoring self.exclude_regex, using the server scan CLI arg
@@ -154,6 +161,7 @@ class BaseTrackedRepo(object):
                     baseline_filename=self.baseline_filename,
                     last_commit_hash=scan_from_this_commit,
                     repo_name=self.name,
+                    extract_pragmas=extract_pragmas,
                 )
         except subprocess.CalledProcessError:
             self.update()

--- a/tests/core/usage/scan_test.py
+++ b/tests/core/usage/scan_test.py
@@ -25,3 +25,9 @@ class TestScanOptions(UsageTest):
                 ' -L examples'
                 ' --output-hook examples/standalone_hook.py'
             )
+    
+    def test_extract_pragmas_flag(self):
+        args = self.parse_args('scan examples -L --extract-pragmas')
+
+        assert args.action == 'scan'
+        assert args.extract_pragmas


### PR DESCRIPTION
🗒️ Description
As a detect-secrets-server user, I would like to extract all pragmas in my codebase where I can validate the use of pragma: allowlist secrets.

💡 Solution
Using the current process that loop through the code and plugin, one more step was added to extract the pragmas. This is an optional feature where on the server side will be triggered through a new flag called --extract-pragmas.

⌛ Time complexity
The performance impact on the scan if this feature is enabled, will be O(n+1) where extract-pragmas is considered an extra plugin run.

🔴 Unit Test
There are unit tests failing that I didn't manage to fix yet, as it was there already.

😎 Hope you guys like this feature, we're already using it in our internal CI process.
👍 Feel free to reach me out.