### PR TITLE
Auto Create 'tracked' Directory

### DIFF
--- a/detect_secrets_server/storage/s3.py
+++ b/detect_secrets_server/storage/s3.py
@@ -23,12 +23,23 @@ class S3Storage(FileStorage):
         self.secret_access_key = s3_config['secret_access_key']
         self.bucket_name = s3_config['bucket']
         self.prefix = s3_config['prefix']
+        self.base_directory = base_directory
 
         self._initialize_client()
 
     def get(self, key, force_download=True):
         """Downloads file from S3 into local storage."""
         file_on_disk = self.get_tracked_file_location(key)
+
+        # If the base directory does not exist a FileNotFoundError is thrown by s3transfer
+        if not os.path.isdir(self.base_directory):
+            print(f'The base directory {self.base_directory} does not exist.')
+        else:
+            local_dest_path = os.path.join(self.base_directory, 'tracked')
+            if not os.path.isdir(local_dest_path):
+                print(f'{local_dest_path} does not exist. Trying to create it')
+                os.mkdir(local_dest_path)
+
         if force_download or not os.path.exists(file_on_disk):
             self.client.download_file(
                 Bucket=self.bucket_name,


### PR DESCRIPTION
I spent some time today trying to setup detect-secrets-server and ran into some issues. I'm using s3 for storage and running inside a Bamboo build environment. I added the tracked repositories on my dev machine, and then tried to run the tool in Bamboo. 

I kept getting this error, no matter if I manually set the root directory or not. 
```
FileNotFoundError: [Errno 2] No such file or directory: '/home/tracked/1c3b04fc...8f.json.92578130'
```

After debugging locally, I realized that the `tracked` subdirectory wasn't being created automatically. It seems like this dir only gets created when adding a repo. This PR adds additional logging, and tries to create the directory if it doesn't exist. If the `tracked` directory doesn't exist, all files downloaded from s3 will fail to save locally. 

I know this tool is setup to use cron, but apart from small gaps like this, there is very little to hold others back from using s3 and running the tool on an ephemeral instance. Thanks for all of your work building this great tool!